### PR TITLE
Updated Default Sprite Retrieval Functionality

### DIFF
--- a/Assets/Packages/com.studio23.ss2.buttoniconresourcemanager/CHANGELOG.md
+++ b/Assets/Packages/com.studio23.ss2.buttoniconresourcemanager/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.0.8](https://github.com/Studio-23-xyz/ButtonIconResourceManager/compare/v2.0.7...v2.0.8) (2023-11-30)
+###Fixed
+
+* Changed default sprite retrieval to be XBox sprites in case of incorrect or unexpected platform names. 
+
 ## [2.0.7](https://github.com/Studio-23-xyz/ButtonIconResourceManager/compare/v2.0.1...v2.0.7) (2023-10-25)
 ### Fixed
 

--- a/Assets/Packages/com.studio23.ss2.buttoniconresourcemanager/Runtime/Data/KeyIcons.cs
+++ b/Assets/Packages/com.studio23.ss2.buttoniconresourcemanager/Runtime/Data/KeyIcons.cs
@@ -41,7 +41,7 @@ namespace Studio23.SS2.ButtonIconResourceManager.Data
 			else if (platform.Contains("xbox") || platform.Contains("xinput") || platform.Contains("gamepad"))
 				return _xboxIcon;
 			else
-				return null;
+				return _xboxIcon;
 		}
 	}
 }

--- a/Assets/Packages/com.studio23.ss2.buttoniconresourcemanager/Tests/Playmode/SpriteRetrievalCheck.cs
+++ b/Assets/Packages/com.studio23.ss2.buttoniconresourcemanager/Tests/Playmode/SpriteRetrievalCheck.cs
@@ -101,4 +101,20 @@ public class SpriteRetrievalCheck
 		Assert.AreEqual("dpad-down", retrievedIcon.name);
 		yield return null;
 	}
+
+	[UnityTest]
+	public IEnumerator _Unexpected_Platform_Name_Dpad_Up_()
+	{
+		var retrievedIcon = KeyIconManager.Instance.GetIcon("failsafe", "dpad/up");
+		Assert.AreEqual("dpad-up", retrievedIcon.name);
+		yield return null;
+	}
+
+	[UnityTest]
+	public IEnumerator _Empty_Or_Null_Platform_Name_Dpad_Left_()
+	{
+		var retrievedIcon = KeyIconManager.Instance.GetIcon("", "dpad/left");
+		Assert.AreEqual("dpad-left", retrievedIcon.name);
+		yield return null;
+	}
 }

--- a/Assets/Packages/com.studio23.ss2.buttoniconresourcemanager/package.json
+++ b/Assets/Packages/com.studio23.ss2.buttoniconresourcemanager/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.studio23.ss2.buttoniconresourcemanager",
   "displayName": "Button Icon Resource Manager",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "unity": "2021.3",
   "unityRelease": "15f1",
   "description": "This package is for managing icons for key bindings for Xbox Controller / Playstation Controller",


### PR DESCRIPTION
## Changes

- Changed default sprite retrieval to XBox sprites in case of incorrect or unexpected platform names.
- Added two new test cases to test for incorrect and empty platform names passed during sprite retrieval request. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved default sprite retrieval to use Xbox sprites for unrecognized or incorrect platform names.

- **Tests**
  - Added tests to ensure correct sprite retrieval for unexpected or empty platform names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->